### PR TITLE
Fix SpikeInterface link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Current `spikeinterface` modules are:
 
 ## Dependencies
 
-To get started with these tutorials, install [spikeinterface](https://github.com/SpikeInterface/pikeinterface).
+To get started with these tutorials, install [spikeinterface](https://github.com/SpikeInterface/spikeinterface).
 Each tutorial contains a requirement and environment file for additional dependencies.
 


### PR DESCRIPTION
I started going through the tutorial and noticed a dropped character in a link.